### PR TITLE
autogenerate the nextauth secret

### DIFF
--- a/templates/genesis/genesis-create-nextauth-token.job.yaml
+++ b/templates/genesis/genesis-create-nextauth-token.job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: genesis-create-nextauth-token
+  namespace: argocd
+spec:
+  template:
+    spec:
+      containers:
+        - name: generate-nextauth-token
+          image: "{{ .Values.registry }}/{{ .Values.image }}"
+          command: ["/create-nextauth-secret"]
+      restartPolicy: OnFailure
+      serviceAccountName: genesis


### PR DESCRIPTION
For the upcoming release, we need to add an autogenerate job.
It uses the existing Genesis image to keep airgap deployments easy&light
on reqs.

This depends on: https://github.com/juno-fx/genesis/issues/552