### PR TITLE
move the ansible CM into genesis-deployment

### DIFF
--- a/templates/genesis/juno-playbook-k3s-provision.cm.yaml
+++ b/templates/genesis/juno-playbook-k3s-provision.cm.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    juno-innovations.com/ansible-playbook: juno-playbook-k3s-provision
+  name: juno-playbook-k3s-provision
+  namespace: argocd
+data:
+  ee-image: junoinnovations/ansible-ee:main
+  playbook.yml: |
+    - name: Run juno_k3s role on target host
+      hosts: all
+      gather_facts: yes
+      vars:
+        ansible_python_interpreter: /usr/bin/python3
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+        k3s_join_token: "{{ lookup('file', '/k3s-join-token') }}"
+        juno_install: false
+        k3s_binary_url: "file:///install_files/k3s"
+        k3s_install_script_url: "file:///install_files/k3s_install.sh"
+      roles:
+        - name: juno-fx.juno_k3s


### PR DESCRIPTION
This tracks the ansible CM that handles node provisioning in argo, as well as adjusts it to be airgap-friendly

### Before requesting review, I have done the following:

- [ ] Code Formatting
- [ ] Linting
- [ ] Added Tests (if any)
- [ ] Updated Documentation (if any)
- [ ] Resolved any Merge Conflicts
