### PR TITLE
escape Jinja's template string to avoid gotmpl interpolating

### DIFF
--- a/templates/genesis/juno-playbook-k3s-provision.cm.yaml
+++ b/templates/genesis/juno-playbook-k3s-provision.cm.yaml
@@ -14,7 +14,7 @@ data:
       vars:
         ansible_python_interpreter: /usr/bin/python3
         ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-        k3s_join_token: "{{ lookup('file', '/k3s-join-token') }}"
+        k3s_join_token: {{ `lookup('file', '/k3s-join-token') }}` | quote }}
         juno_install: false
         k3s_binary_url: "file:///install_files/k3s"
         k3s_install_script_url: "file:///install_files/k3s_install.sh"


### PR DESCRIPTION
This follows up https://github.com/juno-fx/Genesis-Deployment/pull/33

I tested it through `kubectl apply` previously. This accounts for helm trying to render Jinja (which it shouldn't. we want it as-is)