### PR TITLE
read registries.yaml within the provisioning playbook

### DIFF
--- a/templates/genesis/juno-playbook-k3s-provision.cm.yaml
+++ b/templates/genesis/juno-playbook-k3s-provision.cm.yaml
@@ -14,7 +14,8 @@ data:
       vars:
         ansible_python_interpreter: /usr/bin/python3
         ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-        k3s_join_token: {{ `lookup('file', '/k3s-join-token') }}` | quote }}
+        k3s_join_token: "{{ `{{ lookup('file', '/k3s-join-token') }}` }}"
+        k3s_registries_yaml: "{{ `{{ lookup('file', '/k3s-registries.yaml') }}` }}"
         juno_install: false
         k3s_binary_url: "file:///install_files/k3s"
         k3s_install_script_url: "file:///install_files/k3s_install.sh"


### PR DESCRIPTION
This will propagate any airgapped registry config from the controlplane nodes to workers on provisioning.

Without it, the worker nodes don't know where to pull airgapped images from and fail.

