### PR TITLE
ensure the serviceAccount is created at the presync stage

### DIFF
--- a/templates/genesis/account.yaml
+++ b/templates/genesis/account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 metadata:
   name: genesis
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/hook: PreSync

--- a/templates/genesis/binding.yaml
+++ b/templates/genesis/binding.yaml
@@ -3,6 +3,8 @@ kind: ClusterRoleBinding
 metadata:
   name: genesis
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/hook: PreSync
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/genesis/role.yaml
+++ b/templates/genesis/role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: genesis
+  annotations:
+    argocd.argoproj.io/hook: PreSync
   namespace: argocd
 rules:
   - apiGroups: ["*"]


### PR DESCRIPTION
I tested this fixes the linked issue by creating an Application and seeing that it syncs.

We cannot test this with plain helm - argo actually changes the behavior of it, so we have to pass it through to really validate.

```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: genesis
  namespace: argocd
  finalizers:
    - "resources-finalizer.argocd.argoproj.io"
  annotations:
    argocd.argoproj.io/sync-wave: "1"
spec:
  project: default
  destination:
    server: https://kubernetes.default.svc
    namespace: argocd
  syncPolicy:
    automated:
      prune: true
      selfHeal: true
      allowEmpty: true
    syncOptions:
      - CreateNamespace=true
  sources:
    - repoURL: https://github.com/juno-fx/Genesis-Deployment.git
      path: .
      targetRevision: 46-make-sure-the-presync-job-has-got-the-serivceaccount-available-when-it-runs
      helm:
        releaseName: "genesis"
        values: |
          registry: junoinnovations

```

