### PR TITLE
expose tolerations as configurable values

### DIFF
--- a/templates/genesis/genesis.deployment.yaml
+++ b/templates/genesis/genesis.deployment.yaml
@@ -22,6 +22,10 @@ spec:
           {{ $key }}: "{{ $value }}"
         {{- end }}
     spec:
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
       serviceAccountName: genesis
       {{- if .Values.image_pull_secret }}
       imagePullSecrets:

--- a/templates/terra/deployment.yaml
+++ b/templates/terra/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         app: terra
 
     spec:
+      {{- if .Values.terra.tolerations }}
+      tolerations:
+        {{- toYaml .Values.terra.tolerations | nindent 8 }}
+      {{- end }}
       serviceAccountName: terra
       nodeSelector:
         {{- range $key, $value := .Values.terra.node_selector.labels }}

--- a/templates/titan/deployment.yaml
+++ b/templates/titan/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         app: titan
 
     spec:
+      {{- if .Values.titan.tolerations }}
+      tolerations:
+        {{- toYaml .Values.titan.tolerations | nindent 8 }}
+      {{- end }}
       serviceAccountName: titan
       nodeSelector:
         {{- range $key, $value := .Values.titan.node_selector.labels }}

--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,13 @@ node_selector:                              # Node selector to deploy the Genesi
 extra_annotations: {}
 genesis_token_creation_extra_annotations: {}
 
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+# If you run powerful controlplane nodes, you can reuse them to host core Orion services.
+tolerations: []
+
 titan:
+  tolerations: []
   extra_annotations: []
   image: titan:v1.0.3                       # Image to pull for Titan
   owner: bob                                # Owner of the cluster
@@ -28,6 +34,7 @@ titan:
     max_replicas: 3                         # Maximum number of replicas to run
 
 terra:
+  tolerations: []
   extra_annotations: []
   image: terra:v1.0.4                       # Image to pull for Terra
   node_selector:                            # Node selector to deploy the Titan server to


### PR DESCRIPTION
This enables customers to run the core Orion services across their controlplane nodes.

While not as common in pure-cloud envs, onprem infrastructure often has very powerful control plane nodes.

It's not uncommon to see enterprises running part of their core services (such as ArgoCD, which I'd see Genesis/Terra/Titan next to) on that, to use that extra capacity.

I've ran into some problems with this myself in one of the kubeadm deployments I was messing with - bumping this so that those users are covered.
